### PR TITLE
CORE-567: Improve test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ npm run test:github
 
 ### Local
 
-To run against portal running locally on `http://localhost:3000`:
+To run against portal running locally on `http://localhost:3000` or `http://cdp.127.0.0.1.sslip.io:3000`:
+
+> Note to use a different base url, fEx cdp.127.0.0.1.sslip.io:3000 set this value to the env `BASE_URL=cdp.127.0.0.1.sslip.io:3000`
 
 ```bash
 npm run test:local

--- a/test/components/form.component.js
+++ b/test/components/form.component.js
@@ -16,6 +16,10 @@ class FormComponent {
     return $('label*=' + content)
   }
 
+  input(id) {
+    return $(`#${id}`)
+  }
+
   submitButton(content) {
     return $('button*=' + content)
   }

--- a/test/helpers/create-micro-service.js
+++ b/test/helpers/create-micro-service.js
@@ -1,0 +1,49 @@
+import { browser } from '@wdio/globals'
+
+import FormComponent from 'components/form.component'
+import ServicesPage from 'page-objects/services.page'
+
+/**
+ * Helper to create a microservice. Contains no expectations
+ * @param {string} name
+ * @param {('TenantTeam1'|'Platform')} teamName
+ * @returns {Promise<void>}
+ */
+async function createMicroService(name, teamName) {
+  const serviceTypes = ['DotNet Backend', 'Node.js Frontend', 'Node.js Backend']
+  const randomServiceType = Math.floor(Math.random() * serviceTypes.length)
+  const serviceType = serviceTypes[randomServiceType]
+
+  // Choose microservice
+  await FormComponent.inputLabel('Microservice').click()
+  await FormComponent.submitButton('Next').click()
+
+  // Choose detail
+  await FormComponent.inputLabel('Name').click()
+  await browser.keys(name)
+  await FormComponent.inputLabel('Template').click()
+  await browser.keys(serviceType)
+  await FormComponent.inputLabel('Owning Team').click()
+  await browser.keys(teamName)
+  await FormComponent.submitButton('Next').click()
+
+  // Create
+  await FormComponent.submitButton('Create').click()
+
+  // Status page
+  for (const statusTag of [
+    'github-repository',
+    'config',
+    'networking',
+    'proxy',
+    'dashboards',
+    'infrastructure'
+  ]) {
+    await $(`[data-testid="${statusTag}-status-tag"]*=Success`).waitForExist()
+  }
+
+  // Click link to new microservice page
+  await ServicesPage.link('new microservices page').click()
+}
+
+export { createMicroService }

--- a/test/helpers/create-user.js
+++ b/test/helpers/create-user.js
@@ -5,6 +5,11 @@ import FormComponent from 'components/form.component'
 import LinkComponent from 'components/link.component'
 import LoginStubPage from 'page-objects/login-stub.page'
 
+/**
+ * Helper to create a user. Contains no expectations
+ * @param {string} searchTerm
+ * @returns {Promise<void>}
+ */
 async function createUser(searchTerm) {
   await LoginStubPage.loginAsAdmin()
 

--- a/test/specs/services.e2e.js
+++ b/test/specs/services.e2e.js
@@ -1,10 +1,17 @@
-import { browser, expect } from '@wdio/globals'
+import { $, browser, expect } from '@wdio/globals'
 
 import PageHeadingComponent from 'components/page-heading.component'
 import ServicesPage from 'page-objects/services.page'
 import LoginStubPage from 'page-objects/login-stub.page'
+import TabsComponent from 'components/tabs.component.js'
+import LinkComponent from 'components/link.component'
+import DeployPage from 'page-objects/deploy.page.js'
+import HeadingComponent from 'components/heading.component.js'
+import FormComponent from 'components/form.component'
+import CreatePage from 'page-objects/create.page.js'
+import { createMicroService } from 'helpers/create-micro-service.js'
 
-const tenantService = 'cdp-portal-frontend'
+const adminService = 'cdp-portal-frontend'
 
 describe('Services page', () => {
   describe('When logged in as admin user', () => {
@@ -12,7 +19,7 @@ describe('Services page', () => {
       await LoginStubPage.loginAsAdmin()
     })
 
-    it('Should be on the "Services" page', async () => {
+    it("Should be on the 'Services' list page", async () => {
       await ServicesPage.open()
 
       await expect(browser).toHaveTitle(
@@ -23,14 +30,108 @@ describe('Services page', () => {
       await expect(PageHeadingComponent.title('Services')).toExist()
     })
 
-    it('Should navigate to a "Service" page', async () => {
-      await ServicesPage.open(`/${tenantService}`)
+    it("Should navigate to a 'Service' page", async () => {
+      await ServicesPage.open(`/${adminService}`)
       await expect(browser).toHaveTitle(
-        `${tenantService} microservice | Core Delivery Platform - Portal`
+        `${adminService} microservice | Core Delivery Platform - Portal`
       )
       await expect(await ServicesPage.navIsActive()).toBe(true)
-      await expect(PageHeadingComponent.title(tenantService)).toExist()
+      await expect(PageHeadingComponent.title(adminService)).toExist()
       await expect(PageHeadingComponent.caption('Service')).toExist()
+    })
+
+    it("Should be able to see the expected admin tabs on 'Service' page", async () => {
+      await expect(TabsComponent.activeTab()).toHaveText('About')
+      await expect(TabsComponent.tab('Automation')).toExist()
+      await expect(TabsComponent.tab('Buckets')).toExist()
+      await expect(TabsComponent.tab('Proxy')).toExist()
+      await expect(TabsComponent.tab('Secrets')).toExist()
+      await expect(TabsComponent.tab('Terminal')).toExist()
+    })
+
+    it("Should be able to see the 'deploy' button in 'Publish Images' section", async () => {
+      const $publishedImagesSection = $(`[data-testid="published-images"]`)
+      await expect($publishedImagesSection).toExist()
+
+      const $deployButton = await LinkComponent.link('deploy-button', 'Deploy')
+      await expect($deployButton).toExist()
+
+      $deployButton.click()
+    })
+
+    it('Should be redirected to the deploy journey', async () => {
+      await expect(browser).toHaveTitle(
+        'Deploy Service details | Core Delivery Platform - Portal'
+      )
+      await expect(await DeployPage.navIsActive()).toBe(true)
+      await expect(HeadingComponent.title('Details')).toExist()
+      await expect(
+        HeadingComponent.caption(
+          'Provide the microservice image name, version and environment to deploy to.'
+        )
+      ).toExist()
+      await expect(FormComponent.input('image-name')).toHaveValue(adminService)
+    })
+  })
+
+  describe('When logged in as non-admin user', () => {
+    const testRepositoryName = `test-repo-${new Date().getTime()}`
+    const teamName = 'TenantTeam1'
+
+    before(async () => {
+      await LoginStubPage.loginAsNonAdmin()
+      await CreatePage.open()
+      await createMicroService(testRepositoryName, teamName)
+    })
+
+    describe('When viewing microservice as serviceOwner', () => {
+      it("Should navigate to new microservice 'Service' page", async () => {
+        await ServicesPage.open(`/${testRepositoryName}`)
+        await expect(browser).toHaveTitle(
+          `${testRepositoryName} microservice | Core Delivery Platform - Portal`
+        )
+        await expect(await ServicesPage.navIsActive()).toBe(true)
+        await expect(PageHeadingComponent.title(testRepositoryName)).toExist()
+        await expect(PageHeadingComponent.caption('Service')).toExist()
+      })
+
+      it("Should be able to see the expected admin tabs on 'Service' page", async () => {
+        await expect(TabsComponent.activeTab()).toHaveText('About')
+        await expect(TabsComponent.tab('Automation')).toExist()
+        await expect(TabsComponent.tab('Buckets')).toExist()
+        await expect(TabsComponent.tab('Proxy')).toExist()
+        await expect(TabsComponent.tab('Secrets')).toExist()
+        await expect(TabsComponent.tab('Terminal')).toExist()
+      })
+
+      it("Should be able to see the 'deploy' button in 'Publish Images' section", async () => {
+        const $publishedImagesSection = $(`[data-testid="published-images"]`)
+        await expect($publishedImagesSection).toExist()
+
+        const $deployButton = await LinkComponent.link(
+          'deploy-button',
+          'Deploy'
+        )
+        await expect($deployButton).toExist()
+
+        $deployButton.click()
+      })
+
+      it('Should be redirected to the deploy journey', async () => {
+        await expect(browser).toHaveTitle(
+          'Deploy Service details | Core Delivery Platform - Portal'
+        )
+        await expect(await DeployPage.navIsActive()).toBe(true)
+        await expect(HeadingComponent.title('Details')).toExist()
+        await expect(
+          HeadingComponent.caption(
+            'Provide the microservice image name, version and environment to deploy to.'
+          )
+        ).toExist()
+        await expect(FormComponent.input('image-name')).toHaveValue(
+          testRepositoryName
+        )
+      })
     })
   })
 })

--- a/wdio.local.conf.js
+++ b/wdio.local.conf.js
@@ -1,7 +1,7 @@
 import allure from 'allure-commandline'
 
 const debug = process.env.DEBUG
-const baseUrl = process.env.BASE_URL ?? 'localhost:3000'
+const baseUrl = process.env.BASE_URL ?? 'cdp.127.0.0.1.sslip.io:3000'
 const oneMinute = 60 * 1000
 const oneHour = 60 * 60 * 1000
 


### PR DESCRIPTION
Improve test coverage

**Admin**
- As a admin create a new tenant microservice 
- Test items on the service page
- Test deploy button on the service page

**Service Owner**
- As a non admin create a new tenant microservice 
- Test items on the service page
- Test deploy button on the service page


## Associated PR's
- https://github.com/DEFRA/cdp-local-environment/pull/56
- https://github.com/DEFRA/cdp-portal-frontend/pull/807
- https://github.com/DEFRA/cdp-portal-stubs/pull/63